### PR TITLE
Fix add button click to not pass event as overrideWord to addWord()

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,9 @@
             wordsComputed = []
         }
         
-        addButton.addEventListener('click', addWord);
+        addButton.addEventListener('click', () => {
+            addWord()
+        });
         wordInput.addEventListener('keypress', (e) => {
             if (e.key === 'Enter') {
                 addWord();


### PR DESCRIPTION
When I attempted to click the "Add Word" button I got the following error:

```
good-and-evil-concepts/:273 Uncaught (in promise) TypeError: e.split is not a function
    at Function._encode_text (transformers@3.3.2:1:677276)
    at Function._tokenize_helper (transformers@3.3.2:1:678154)
    at Function._encode_plus (transformers@3.3.2:1:677868)
    at Function._call (transformers@3.3.2:1:676049)
    at Function.e [as tokenizer] (transformers@3.3.2:1:706037)
    at Function._call (transformers@3.3.2:1:633623)
    at e (transformers@3.3.2:1:706037)
    at HTMLButtonElement.addWord (good-and-evil-concepts/:241:48)
```

I saw that it was because the `click` event handler was passing the pointer click `Event` to `addWord()` which was getting set to `overrideWord` and this `Event` was not in fact a word.